### PR TITLE
Fix errors on node v0.6

### DIFF
--- a/trace.js
+++ b/trace.js
@@ -208,8 +208,8 @@ var trace = function(err) {
       match1, match2;
 
   frames = stack.map(function(line) {
-    match1 = err_re1(line);
-    match2 = err_re2(line);
+    match1 = err_re1.exec(line);
+    match2 = err_re2.exec(line);
 
     if(match1) {
         return new Frame(match1[1], match1[2], parseInt(match1[3], 10), parseInt(match1[4], 10))


### PR DESCRIPTION
Tests now pass on node v0.6.0, v0.6.2. There was an error with calling a RegExp as a function, so I switched tracejs to use `exec`.
